### PR TITLE
Remove default security context to support access Swagger via Jobroom

### DIFF
--- a/web/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/web/config/SwaggerConfig.java
+++ b/web/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/web/config/SwaggerConfig.java
@@ -53,6 +53,17 @@ class SwaggerConfig {
                     .paths(regex("/api/.*"))
                     .build()
                     .directModelSubstitute(LocalDate.class, java.sql.Date.class)
+                    .directModelSubstitute(LocalDateTime.class, java.util.Date.class);
+        }
+
+        @Bean
+        public Docket publicApiWithSecurity() {
+            return new Docket(DocumentationType.SWAGGER_2)
+                    .groupName("public-api")
+                    .select()
+                    .paths(regex("/api/.*"))
+                    .build()
+                    .directModelSubstitute(LocalDate.class, java.sql.Date.class)
                     .directModelSubstitute(LocalDateTime.class, java.util.Date.class)
                     .securityContexts(Collections.singletonList(securityContext()))
                     .securitySchemes(Collections.singletonList(apiKey()));


### PR DESCRIPTION
- access swagger via the Jobroom Admin menu
  (which supports only the default swagger group)
- supports JWT security out of the box
- open: Nevis support (only cookie required?)