### PR TITLE
Bugfix/jr2-1293 reverted not null condition for number of jobs

### DIFF
--- a/domain/src/main/java/ch/admin/seco/jobs/services/jobadservice/domain/jobadvertisement/JobContent.java
+++ b/domain/src/main/java/ch/admin/seco/jobs/services/jobadservice/domain/jobadvertisement/JobContent.java
@@ -20,7 +20,6 @@ public class JobContent implements ValueObject<JobContent> {
     @Column(name = "X28_OCCUPATION_CODES")
     private String x28OccupationCodes;
 
-    @NotBlank
     private String numberOfJobs;
 
     @ElementCollection
@@ -143,7 +142,6 @@ public class JobContent implements ValueObject<JobContent> {
         this.applyChannel = builder.applyChannel;
         this.location = builder.location;
         this.occupations = Condition.notEmpty(builder.occupations, "Occupations can't be null or empty");
-		this.setNumberOfJobs(builder.numberOfJobs);
     }
 
     public String getExternalUrl() {
@@ -167,11 +165,7 @@ public class JobContent implements ValueObject<JobContent> {
     }
 
     void setNumberOfJobs(String numberOfJobs) {
-        try {
-            this.numberOfJobs = Condition.notBlank(numberOfJobs);
-        } catch (ConditionException e){
-            this.numberOfJobs = "1";
-        }
+            this.numberOfJobs = numberOfJobs;
     }
 
     public List<JobDescription> getJobDescriptions() {

--- a/web/src/main/resources/liquibase/changelog/20180823080000_revert_null_constraint_JobAdvertisement_numberOfJobs.xml
+++ b/web/src/main/resources/liquibase/changelog/20180823080000_revert_null_constraint_JobAdvertisement_numberOfJobs.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="20180823080000-1" author="alnu">
+        <preConditions onFail="MARK_RAN">
+            <changeSetExecuted id="20180814080000-1" author="alnu" changeLogFile="classpath:/liquibase/changelog/20180814080000_update_JobAdvertisement_numberOfJobs.xml"/>
+        </preConditions>
+        <dropNotNullConstraint tableName="JOB_ADVERTISEMENT" columnName="NUMBER_OF_JOBS" columnDataType="VARCHAR(5)" />
+        <sql>
+            update JOB_ADVERTISEMENT
+            set NUMBER_OF_JOBS = null
+            where NUMBER_OF_JOBS = '1'
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/web/src/main/resources/liquibase/master.xml
+++ b/web/src/main/resources/liquibase/master.xml
@@ -16,6 +16,6 @@
     <include file="classpath:/liquibase/changelog/20180726150000_added_entity_x28_message_log.xml" relativeToChangelogFile="false"/>
     <include file="classpath:/liquibase/changelog/20180813130000_update_JobAdvertisement_location_city" relativeToChangelogFile="false"/>
     <include file="classpath:/liquibase/changelog/20180813140000_lower-case-lang-iso-codes.xml" relativeToChangelogFile="false"/>
-    <include file="classpath:/liquibase/changelog/20180814080000_update_JobAdvertisement_numberOfJobs.xml" relativeToChangelogFile="false"/>
     <include file="classpath:/liquibase/changelog/20180817080000_added_entity_MailSendingTask.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:/liquibase/changelog/20180823080000_revert_null_constraint_JobAdvertisement_numberOfJobs.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>


### PR DESCRIPTION
* Reverted notBlank for checking presence numberOfJobs on JobContent.java.

* Removed 20180814080000_update_JobAdvertisement_numberOfJobs.xml from master.xml changelog. This will prevent execution of this changeset on environments where it was never executed. Added changeset 20180823080000_revert_null_constraint_JobAdvertisement_numberOfJobs.xml with precondition to be run ONLY in case of 0180814080000_update_JobAdvertisement_numberOfJobs.xml had already been executed.