### PR TITLE
DF-400 fix composition of company address

### DIFF
--- a/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/jobadvertisement/dto/CompanyDto.java
+++ b/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/jobadvertisement/dto/CompanyDto.java
@@ -14,10 +14,8 @@ public class CompanyDto {
 
     private String houseNumber;
 
-    @NotBlank
     private String postalCode;
 
-    @NotBlank
     private String city;
 
     @NotBlank


### PR DESCRIPTION
removed @NotBlank from postalCode and city in CompanyDto.java because these fields are not required if postOffice*-Fields are set.