### PR TITLE
DF 2213 - delete data on unregistering user

### DIFF
--- a/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/LoginAsTechnicalUser.java
+++ b/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/LoginAsTechnicalUser.java
@@ -1,4 +1,4 @@
-package ch.admin.seco.jobs.services.jobadservice.infrastructure;
+package ch.admin.seco.jobs.services.jobadservice.application;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/favouriteitem/FavouriteItemApplicationService.java
+++ b/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/favouriteitem/FavouriteItemApplicationService.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import static ch.admin.seco.jobs.services.jobadservice.application.BusinessLogConstants.STATUS_ADDITIONAL_DATA;
 import static ch.admin.seco.jobs.services.jobadservice.application.BusinessLogEventType.JOB_ADVERTISEMENT_FAVORITE_EVENT;
 import static ch.admin.seco.jobs.services.jobadservice.application.BusinessLogObjectType.JOB_ADVERTISEMENT_LOG;
-import static org.springframework.util.Assert.notNull;
 
 @Service
 @Transactional
@@ -120,9 +119,9 @@ public class FavouriteItemApplicationService {
     }
 
     @IsSysAdmin
-    public void handleUserUnregisteredEvent(String ownerUserId) {
-        notNull(ownerUserId, "OwnerUserId can't be null");
-        List<FavouriteItem> favouriteItems = this.favouriteItemRepository.findByOwnerUserId(ownerUserId);
+    public void deleteUserFavouriteItems(String ownerUserId) {
+        Condition.notNull(ownerUserId, "OwnerUserId can't be null");
+        List<FavouriteItem> favouriteItems = this.favouriteItemRepository.findAllByOwnerUserId(ownerUserId);
         favouriteItems.forEach(favouriteItem -> {
             this.favouriteItemRepository.delete(favouriteItem);
             DomainEventPublisher.publish(new FavouriteItemDeletedEvent(favouriteItem));

--- a/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/searchprofile/SearchProfileApplicationService.java
+++ b/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/searchprofile/SearchProfileApplicationService.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.springframework.data.domain.Sort.Order.desc;
-import static org.springframework.util.Assert.notNull;
 
 @Service
 @Transactional
@@ -116,8 +115,8 @@ public class SearchProfileApplicationService {
 	}
 
 	@IsSysAdmin
-	public void handleUserUnregisteredEvent(String ownerUserId) {
-		notNull(ownerUserId, "OwnerUserId can't be null");
+	public void deleteUserSearchProfiles(String ownerUserId) {
+		Condition.notNull(ownerUserId, "OwnerUserId can't be null");
 		List<SearchProfile> searchProfiles = this.searchProfileRepository.findAllByOwnerUserId(ownerUserId);
 		searchProfiles.forEach(searchProfile -> {
 			this.searchProfileRepository.delete(searchProfile);

--- a/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/security/TechnicalUserConfig.java
+++ b/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/security/TechnicalUserConfig.java
@@ -1,0 +1,13 @@
+package ch.admin.seco.jobs.services.jobadservice.application.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class TechnicalUserConfig {
+
+	@Bean
+	TechnicalUserContextAspect technicalUserContextAspect() {
+		return new TechnicalUserContextAspect();
+	}
+}

--- a/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/security/TechnicalUserContextAspect.java
+++ b/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/security/TechnicalUserContextAspect.java
@@ -1,0 +1,24 @@
+package ch.admin.seco.jobs.services.jobadservice.application.security;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+@Aspect
+class TechnicalUserContextAspect {
+
+	@Pointcut("@annotation(ch.admin.seco.jobs.services.jobadservice.application.LoginAsTechnicalUser)")
+	void loginAsTechnicalUserPointcut() {
+	}
+
+	@Around("loginAsTechnicalUserPointcut() ")
+	Object initSecurityContextAround(ProceedingJoinPoint joinPoint) throws Throwable {
+		try {
+			TechnicalUserContextUtil.initContext();
+			return joinPoint.proceed();
+		} finally {
+			TechnicalUserContextUtil.clearContext();
+		}
+	}
+}

--- a/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/security/TechnicalUserContextUtil.java
+++ b/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/security/TechnicalUserContextUtil.java
@@ -1,0 +1,65 @@
+package ch.admin.seco.jobs.services.jobadservice.application.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+final class TechnicalUserContextUtil {
+
+	private static final String DEFAULT_ROLE = Role.SYSADMIN.getValue();
+
+	private static final String TECH_USER_ID = "tech-user-id";
+
+	private static final String TECH_USER_NAME = "Tech-User";
+
+	private static final String TECH_USER_EMAIL = "techuser@example.com";
+
+	private static final String TECH_USER_EXT_ID = "tech-user-ext-id";
+
+	private TechnicalUserContextUtil() {
+	}
+
+	static void initContext() {
+		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+		List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList(DEFAULT_ROLE);
+		securityContext.setAuthentication(prepareAuthentication(authorities));
+		SecurityContextHolder.setContext(securityContext);
+	}
+
+	static void clearContext() {
+		SecurityContextHolder.clearContext();
+	}
+
+	private static UsernamePasswordAuthenticationToken prepareAuthentication(List<GrantedAuthority> authorities) {
+		return new UsernamePasswordAuthenticationToken(prepareUser(authorities), null, authorities);
+	}
+
+	private static UserDetailsToCurrentUserAdapter prepareUser(List<GrantedAuthority> authorities) {
+		CurrentUser currentUser = new CurrentUser(
+				TECH_USER_ID,
+				TECH_USER_EXT_ID,
+				null,
+				TECH_USER_NAME,
+				TECH_USER_NAME,
+				TECH_USER_EMAIL,
+				extractAuthorities(authorities)
+		);
+		return new UserDetailsToCurrentUserAdapter(
+				TECH_USER_NAME,
+				"N/A",
+				currentUser,
+				authorities
+		);
+	}
+
+	private static Set<String> extractAuthorities(List<GrantedAuthority> authorities) {
+		return authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet());
+	}
+
+}

--- a/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/security/UserDetailsToCurrentUserAdapter.java
+++ b/application/src/main/java/ch/admin/seco/jobs/services/jobadservice/application/security/UserDetailsToCurrentUserAdapter.java
@@ -1,0 +1,20 @@
+package ch.admin.seco.jobs.services.jobadservice.application.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+public class UserDetailsToCurrentUserAdapter extends User {
+
+	private final CurrentUser currentUser;
+
+	public UserDetailsToCurrentUserAdapter(String username, String password, CurrentUser currentUser, Collection<? extends GrantedAuthority> authorities) {
+		super(username, password, true, true, true, true, authorities);
+		this.currentUser = currentUser;
+	}
+
+	CurrentUser getCurrentUser() {
+		return currentUser;
+	}
+}

--- a/domain/src/main/java/ch/admin/seco/jobs/services/jobadservice/domain/favouriteitem/FavouriteItemRepository.java
+++ b/domain/src/main/java/ch/admin/seco/jobs/services/jobadservice/domain/favouriteitem/FavouriteItemRepository.java
@@ -28,6 +28,10 @@ public interface FavouriteItemRepository extends JpaRepository<FavouriteItem, Fa
     @Query("select i from FavouriteItem i where i.jobAdvertisementId in :jobAdvertisementIds and i.ownerUserId = :ownerUserId")
     List<FavouriteItem> findByJobAdvertisementIdsAndOwnerId(@Param("jobAdvertisementIds") Set<JobAdvertisementId> jobAdvertisementIds, @Param("ownerUserId") String ownerUserId);
 
+    @Transactional(propagation = Propagation.SUPPORTS)
+    @Query("select i from FavouriteItem i where i.ownerUserId = :ownerUserId")
+    List<FavouriteItem> findByOwnerUserId(@Param("ownerUserId") String ownerUserId);
+
     @QueryHints({
             @QueryHint(name = HINT_FETCH_SIZE, value = "1000"),
             @QueryHint(name = HINT_CACHE_MODE, value = "IGNORE")})

--- a/domain/src/main/java/ch/admin/seco/jobs/services/jobadservice/domain/favouriteitem/FavouriteItemRepository.java
+++ b/domain/src/main/java/ch/admin/seco/jobs/services/jobadservice/domain/favouriteitem/FavouriteItemRepository.java
@@ -30,7 +30,7 @@ public interface FavouriteItemRepository extends JpaRepository<FavouriteItem, Fa
 
     @Transactional(propagation = Propagation.SUPPORTS)
     @Query("select i from FavouriteItem i where i.ownerUserId = :ownerUserId")
-    List<FavouriteItem> findByOwnerUserId(@Param("ownerUserId") String ownerUserId);
+    List<FavouriteItem> findAllByOwnerUserId(@Param("ownerUserId") String ownerUserId);
 
     @QueryHints({
             @QueryHint(name = HINT_FETCH_SIZE, value = "1000"),

--- a/domain/src/main/java/ch/admin/seco/jobs/services/jobadservice/domain/searchprofile/SearchProfileRepository.java
+++ b/domain/src/main/java/ch/admin/seco/jobs/services/jobadservice/domain/searchprofile/SearchProfileRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Transactional(propagation = Propagation.MANDATORY)
@@ -20,4 +21,9 @@ public interface SearchProfileRepository extends JpaRepository<SearchProfile, Se
     @Transactional(propagation = Propagation.SUPPORTS)
     @Query("select sp from SearchProfile sp where sp.ownerUserId = :ownerUserId")
     Page<SearchProfile> findAllByOwnerUserId(@Param("ownerUserId") String ownerUserId, Pageable pageable);
+
+    @Transactional(propagation = Propagation.SUPPORTS)
+    @Query("select sp from SearchProfile sp where sp.ownerUserId = :ownerUserId")
+    List<SearchProfile> findAllByOwnerUserId(@Param("ownerUserId") String ownerUserId);
+
 }

--- a/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/LoginAsTechnicalUser.java
+++ b/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/LoginAsTechnicalUser.java
@@ -1,0 +1,11 @@
+package ch.admin.seco.jobs.services.jobadservice.infrastructure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginAsTechnicalUser {
+}

--- a/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/MessageBrokerChannels.java
+++ b/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/MessageBrokerChannels.java
@@ -18,6 +18,11 @@ public interface MessageBrokerChannels {
 
     String JOB_AD_INT_EVENT_CHANNEL = "job-ad-int-event";
 
+    String USER_EVENT_CHANNEL = "user-event";
+
+    @Input(USER_EVENT_CHANNEL)
+    SubscribableChannel userEventChannel();
+
     @Input(JOB_AD_INT_ACTION_CHANNEL)
     SubscribableChannel jobAdIntActionChannel();
 

--- a/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/MessageBrokerConfig.java
+++ b/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/MessageBrokerConfig.java
@@ -26,8 +26,14 @@ public class MessageBrokerConfig {
         @Bean
         MessageBrokerChannels messageBrokerChannels() {
             return new MessageBrokerChannels() {
+
                 @Override
                 public SubscribableChannel jobAdIntActionChannel() {
+                    return new DirectChannel();
+                }
+
+                @Override
+                public SubscribableChannel userEventChannel() {
                     return new DirectChannel();
                 }
 

--- a/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/users/UserEventDto.java
+++ b/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/users/UserEventDto.java
@@ -1,0 +1,27 @@
+package ch.admin.seco.jobs.services.jobadservice.infrastructure.messagebroker.users;
+
+public class UserEventDto {
+
+    private String userInfoId;
+
+    private String userInfoRole;
+
+    public String getUserInfoId() {
+        return userInfoId;
+    }
+
+    public UserEventDto setUserInfoId(String userInfoId) {
+        this.userInfoId = userInfoId;
+        return this;
+    }
+
+    public String getUserInfoRole() {
+        return userInfoRole;
+    }
+
+    public UserEventDto setUserInfoRole(String userInfoRole) {
+        this.userInfoRole = userInfoRole;
+        return this;
+    }
+
+}

--- a/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/users/UserEventReceiverGateway.java
+++ b/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/users/UserEventReceiverGateway.java
@@ -2,7 +2,7 @@ package ch.admin.seco.jobs.services.jobadservice.infrastructure.messagebroker.us
 
 import ch.admin.seco.jobs.services.jobadservice.application.favouriteitem.FavouriteItemApplicationService;
 import ch.admin.seco.jobs.services.jobadservice.application.searchprofile.SearchProfileApplicationService;
-import ch.admin.seco.jobs.services.jobadservice.infrastructure.LoginAsTechnicalUser;
+import ch.admin.seco.jobs.services.jobadservice.application.LoginAsTechnicalUser;
 import ch.admin.seco.jobs.services.jobadservice.infrastructure.messagebroker.MessageBrokerChannels;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,8 +29,8 @@ public class UserEventReceiverGateway {
     @LoginAsTechnicalUser
     public void handleUnregisteredEvent(UserEventDto event) {
         LOGGER.info("Received UserUnregisteredEvent for User: '{}' with Role: '{}'.", event.getUserInfoId(), event.getUserInfoRole());
-        this.searchProfileApplicationService.handleUserUnregisteredEvent(event.getUserInfoId());
-        this.favouriteItemApplicationService.handleUserUnregisteredEvent(event.getUserInfoId());
+        this.searchProfileApplicationService.deleteUserSearchProfiles(event.getUserInfoId());
+        this.favouriteItemApplicationService.deleteUserFavouriteItems(event.getUserInfoId());
     }
 
 }

--- a/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/users/UserEventReceiverGateway.java
+++ b/infrastructure-messagebroker/src/main/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/users/UserEventReceiverGateway.java
@@ -1,0 +1,36 @@
+package ch.admin.seco.jobs.services.jobadservice.infrastructure.messagebroker.users;
+
+import ch.admin.seco.jobs.services.jobadservice.application.favouriteitem.FavouriteItemApplicationService;
+import ch.admin.seco.jobs.services.jobadservice.application.searchprofile.SearchProfileApplicationService;
+import ch.admin.seco.jobs.services.jobadservice.infrastructure.LoginAsTechnicalUser;
+import ch.admin.seco.jobs.services.jobadservice.infrastructure.messagebroker.MessageBrokerChannels;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserEventReceiverGateway {
+
+    private static final String UNREGISTERED_EVENT_CONDITION = "headers['event']=='UNREGISTERED'";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserEventReceiverGateway.class);
+
+    private final SearchProfileApplicationService searchProfileApplicationService;
+
+    private final FavouriteItemApplicationService favouriteItemApplicationService;
+
+    UserEventReceiverGateway(SearchProfileApplicationService searchProfileApplicationService, FavouriteItemApplicationService favouriteItemApplicationService) {
+        this.searchProfileApplicationService = searchProfileApplicationService;
+        this.favouriteItemApplicationService = favouriteItemApplicationService;
+    }
+
+    @StreamListener(value = MessageBrokerChannels.USER_EVENT_CHANNEL, condition = UNREGISTERED_EVENT_CONDITION)
+    @LoginAsTechnicalUser
+    public void handleUnregisteredEvent(UserEventDto event) {
+        LOGGER.info("Received UserUnregisteredEvent for User: '{}' with Role: '{}'.", event.getUserInfoId(), event.getUserInfoRole());
+        this.searchProfileApplicationService.handleUserUnregisteredEvent(event.getUserInfoId());
+        this.favouriteItemApplicationService.handleUserUnregisteredEvent(event.getUserInfoId());
+    }
+
+}

--- a/infrastructure-messagebroker/src/test/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/avam/TestConfig.java
+++ b/infrastructure-messagebroker/src/test/java/ch/admin/seco/jobs/services/jobadservice/infrastructure/messagebroker/avam/TestConfig.java
@@ -1,5 +1,10 @@
 package ch.admin.seco.jobs.services.jobadservice.infrastructure.messagebroker.avam;
 
+import ch.admin.seco.jobs.services.jobadservice.application.JobCenterService;
+import ch.admin.seco.jobs.services.jobadservice.application.MailSenderService;
+import ch.admin.seco.jobs.services.jobadservice.application.jobadvertisement.JobAdvertisementApplicationService;
+import ch.admin.seco.jobs.services.jobadservice.domain.jobadvertisement.JobAdvertisementRepository;
+import ch.admin.seco.jobs.services.jobadservice.infrastructure.messagebroker.MessageBrokerChannels;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
@@ -7,12 +12,6 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
-
-import ch.admin.seco.jobs.services.jobadservice.application.JobCenterService;
-import ch.admin.seco.jobs.services.jobadservice.application.MailSenderService;
-import ch.admin.seco.jobs.services.jobadservice.application.jobadvertisement.JobAdvertisementApplicationService;
-import ch.admin.seco.jobs.services.jobadservice.domain.jobadvertisement.JobAdvertisementRepository;
-import ch.admin.seco.jobs.services.jobadservice.infrastructure.messagebroker.MessageBrokerChannels;
 
 @SpringBootApplication
 public class TestConfig {
@@ -32,8 +31,14 @@ public class TestConfig {
 	@Bean
 	MessageBrokerChannels messageBrokerChannels() {
 		return new MessageBrokerChannels() {
+
 			@Override
 			public SubscribableChannel jobAdIntActionChannel() {
+				return new DirectChannel();
+			}
+
+			@Override
+			public SubscribableChannel userEventChannel() {
 				return new DirectChannel();
 			}
 

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -36,6 +36,9 @@ spring.cloud.stream.bindings.job-ad-int-action.consumer.max-attempts=1
 # Bindings settings for job-ad-int-event
 spring.cloud.stream.bindings.job-ad-int-event.destination=jobadint.event
 spring.cloud.stream.bindings.job-ad-int-event.group=jobadservice
+# Bindings settings for user-event
+spring.cloud.stream.bindings.user-event.destination=user.event
+spring.cloud.stream.bindings.juser-event.group=jobadservice
 # Bindings settings for job-ad-event
 spring.cloud.stream.bindings.job-ad-event.destination=jobad.event
 spring.cloud.stream.bindings.job-ad-event.group=jobadservice
@@ -45,6 +48,9 @@ spring.cloud.stream.kafka.binder.auto-add-partitions=true
 # Kafka specific settings for job-ad-int-action
 spring.cloud.stream.kafka.bindings.job-ad-int-action.consumer.enable-dlq=true
 spring.cloud.stream.kafka.bindings.job-ad-int-action.consumer.dlq-name=jobadint.action.dlq
+# Kafka specific settings for user-event
+spring.cloud.stream.kafka.bindings.user-event.consumer.enable-dlq=true
+spring.cloud.stream.kafka.bindings.user-event.consumer.dlq-name=user.event.dlq
 # Kafka specific settings for job-ad-int-event
 spring.cloud.stream.kafka.bindings.job-ad-int-event.producer.sync=true
 # Kafka specific settings for job-ad-event


### PR DESCRIPTION
- first draft

**TODO** : 
-- we have to trigger `JobAlertUnsubscribedEvent` on deleting SearchPofile, so the elasticsearch query from percolator is also deleted. --> https://alv-ch.atlassian.net/browse/DF-2276

Delete JobAdSearchProfile and JobAdFavouriteItem on UserUnregisteredEvent.

OS: https://github.com/alv-ch/alv-onlineform-service/pull/112
JOBROOM: https://github.com/alv-ch/jobroom2/pull/907
CANDIDATE: https://github.com/alv-ch/candidate-service/pull/170
JOBAD: https://github.com/alv-ch/job-ad-service/pull/442